### PR TITLE
Fixed class loader

### DIFF
--- a/SampleModule/SampleModule.psm1
+++ b/SampleModule/SampleModule.psm1
@@ -1,27 +1,28 @@
 ##Import Classes
 $ClassLoadOrder = Import-PowerShellDataFile -Path $PSScriptRoot\Classes\classes.psd1 -ErrorAction SilentlyContinue
 foreach ($class in $ClassLoadOrder.LoadingData) {
-    if (($ClassFile = Resolve-Path $PSScriptRoot\Classes\$class[0].ps1) -and (Test-Path $ClassFile)) {
-        . $ClassFile.FullName
+    $path = '{0}\classes\{1}.ps1' -f $PSScriptRoot, $class[0]
+    if (Test-Path $path) {
+        . $path
     }
 }
 
 #Get public and private function definition files.
-    $Public  = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue )
-    $Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue )
+$Public  = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue )
+$Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue )
 
 #Dot source the files
-    Foreach($import in @($Public + $Private))
+Foreach($import in @($Public + $Private))
+{
+    Try
     {
-        Try
-        {
-            . $import.fullname
-        }
-        Catch
-        {
-            Write-Error -Message "Failed to import function $($import.fullname): $_"
-        }
+        . $import.fullname
     }
+    Catch
+    {
+        Write-Error -Message "Failed to import function $($import.fullname): $_"
+    }
+}
 
 Export-ModuleMember -Function $Public.Basename
 


### PR DESCRIPTION
The class loader is a nasty bit of code dependent on a rather unpleasant data structure. There's no need to use Resolve-Path if there are no wildcards, it's been taken out leaving Test-Path.

This should allow the new unit tests to test the class implementation.