### PR TITLE
changing the codecoveragethreshold to 80 as default module gets 83% only

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -20,7 +20,7 @@ Param (
 
     $MergeList = @('enum*',[PSCustomObject]@{Name='class*';order={(Import-PowerShellDataFile -EA 0 .\*\Classes\classes.psd1).order.indexOf($_.BaseName)}},'priv*','pub*')
     
-    ,$CodeCoverageThreshold = 90
+    ,$CodeCoverageThreshold = 80
 )
 
 Process {


### PR DESCRIPTION
a module built with that template without classes but the basic scripts would get a codecoverage of only 83.333%. Most likely because of the DSC ressource not yet tested.

Bringing down the threshold to 80% means a simple module from template should build successfully straight away, out of the 'box'.