### PR TITLE
Improved InvokeBuild output using Buildheaders

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -20,6 +20,16 @@ Param (
 
     $MergeList = @('enum*',[PSCustomObject]@{Name='class*';order={(Import-PowerShellDataFile -EA 0 .\*\Classes\classes.psd1).order.indexOf($_.BaseName)}},'priv*','pub*')
     
+    ,$TaskHeader = {
+        param($Path)
+        '=' * 79
+        Write-Build Cyan "`t`t`t$($Task.Name.replace('_',' ').ToUpper())"
+        Write-Build DarkGray  "$(Get-BuildSynopsis $Task)"
+        '-' * 79
+        Write-Build DarkGray "  $($Task.InvocationInfo.ScriptName):$($Task.InvocationInfo.ScriptLineNumber)"
+        ''
+    }
+
     ,$CodeCoverageThreshold = 80
 )
 
@@ -46,6 +56,9 @@ Process {
             "Importing file $($_.BaseName)" | Write-Verbose
             . $_.FullName 
         }
+    
+    Set-BuildHeader $TaskHeader
+
     task .  Clean,
             SetBuildEnvironment,
             QualityTestsStopOnFail,

--- a/.build.ps1
+++ b/.build.ps1
@@ -68,8 +68,8 @@ Process {
             Merge_Source_Files_To_PSM1,
             Clean_Empty_Folders_from_Build_Output,
             Update_Module_Manifest,
-            Unit_Tests,
-            UploadUnitTestResultsToAppVeyor,
+            Run_Unit_Tests,
+            Upload_Unit_Test_Results_To_AppVeyor,
             Fail_Build_if_Unit_Test_Failed, 
             Fail_if_Last_Code_Converage_is_Under_Threshold,
             IntegrationTests,
@@ -77,6 +77,7 @@ Process {
 
     task testAll UnitTests, IntegrationTests, QualityTestsStopOnFail
 
+    task Noop {}
 
 }
 

--- a/.build.ps1
+++ b/.build.ps1
@@ -22,10 +22,12 @@ Param (
     
     ,$TaskHeader = {
         param($Path)
+        ''
         '=' * 79
         Write-Build Cyan "`t`t`t$($Task.Name.replace('_',' ').ToUpper())"
         Write-Build DarkGray  "$(Get-BuildSynopsis $Task)"
         '-' * 79
+        Write-Build DarkGray "  $Path"
         Write-Build DarkGray "  $($Task.InvocationInfo.ScriptName):$($Task.InvocationInfo.ScriptLineNumber)"
         ''
     }
@@ -60,18 +62,18 @@ Process {
     Set-BuildHeader $TaskHeader
 
     task .  Clean,
-            SetBuildEnvironment,
-            QualityTestsStopOnFail,
-            CopySourceToModuleOut,
-            MergeFilesToPSM1,
-            CleanOutputEmptyFolders,
-            UpdateModuleManifest,
-            UnitTests,
+            Set_Build_Environment_Variables,
+            Pester_Quality_Tests_Stop_On_Fail,
+            Copy_Source_To_Module_BuildOutput,
+            Merge_Source_Files_To_PSM1,
+            Clean_Empty_Folders_from_Build_Output,
+            Update_Module_Manifest,
+            Unit_Tests,
             UploadUnitTestResultsToAppVeyor,
-            FailBuildIfFailedUnitTest, 
-            FailIfLastCodeConverageUnderThreshold,
+            Fail_Build_if_Unit_Test_Failed, 
+            Fail_if_Last_Code_Converage_is_Under_Threshold,
             IntegrationTests,
-            DeployAll
+            Deploy_with_PSDeploy
 
     task testAll UnitTests, IntegrationTests, QualityTestsStopOnFail
 

--- a/.build/Appveyor/TestResultUpload.Appveyor.build.ps1
+++ b/.build/Appveyor/TestResultUpload.Appveyor.build.ps1
@@ -13,7 +13,7 @@ Param (
 )
 
 # Synopsis: Uploading Unit Test results to AppVeyor
-task UploadUnitTestResultsToAppVeyor -If {(property BuildSystem 'unknown') -eq 'AppVeyor'} {
+task Upload_Unit_Test_Results_To_AppVeyor -If {(property BuildSystem 'unknown') -eq 'AppVeyor'} {
 
     if (![io.path]::IsPathRooted($BuildOutput)) {
         $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
@@ -21,5 +21,7 @@ task UploadUnitTestResultsToAppVeyor -If {(property BuildSystem 'unknown') -eq '
 
     $TestOutputPath  = [system.io.path]::Combine($BuildOutput,'testResults','unit',$PesterOutputFormat)
     $TestResultFiles = Get-ChildItem -Path $TestOutputPath -Filter *.xml
+    Write-Build Green "  Uploading test results [$($TestResultFiles.Name -join ', ')] to Appveyor"
     $TestResultFiles | Add-TestResultToAppveyor
+    Write-Build Green "  Upload Complete"
 }

--- a/.build/Appveyor/TestResultUpload.Appveyor.build.ps1
+++ b/.build/Appveyor/TestResultUpload.Appveyor.build.ps1
@@ -1,12 +1,9 @@
 Param (
-    [io.DirectoryInfo]
-    $ProjectPath = (property ProjectPath (Join-Path $PSScriptRoot '../..' -Resolve -ErrorAction SilentlyContinue)),
+    [string]
+    $BuildOutput = (property BuildOutput 'BuildOutput'),
 
     [string]
-    $BuildOutput = (property BuildOutput 'C:\BuildOutput'),
-
-    [string]
-    $ProjectName = (property ProjectName (Split-Path -Leaf (Join-Path $PSScriptRoot '../..')) ),
+    $ProjectName = (property ProjectName (Split-Path -Leaf $BuildRoot) ),
 
     [string]
     $PesterOutputFormat = (property PesterOutputFormat 'NUnitXml'),
@@ -15,13 +12,11 @@ Param (
     $APPVEYOR_JOB_ID = $(try {property APPVEYOR_JOB_ID} catch {})
 )
 
+# Synopsis: Uploading Unit Test results to AppVeyor
 task UploadUnitTestResultsToAppVeyor -If {(property BuildSystem 'unknown') -eq 'AppVeyor'} {
-    $LineSeparation
-    "`t`t`UPLOAD TEST RESULT TO APPVEYOR"
-    $LineSeparation
 
     if (![io.path]::IsPathRooted($BuildOutput)) {
-        $BuildOutput = Join-Path -Path $ProjectPath.FullName -ChildPath $BuildOutput
+        $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
     }
 
     $TestOutputPath  = [system.io.path]::Combine($BuildOutput,'testResults','unit',$PesterOutputFormat)

--- a/.build/BuildHelpers/Clean.BuildHelpers.build.ps1
+++ b/.build/BuildHelpers/Clean.BuildHelpers.build.ps1
@@ -1,34 +1,28 @@
 Param (
-
-    [io.DirectoryInfo]
-    $ProjectPath = (property ProjectPath (Join-Path $PSScriptRoot '../..' -Resolve -ErrorAction SilentlyContinue)),
-
     [string]
-    $BuildOutput = (property BuildOutput 'C:\BuildOutput'),
-
-    [string]
-    $LineSeparation = (property LineSeparation ('-' * 78)) 
+    $BuildOutput = (property BuildOutput 'BuildOutput')
 )
 
+# Removes the BuildOutput\modules (errors if Pester is loaded)
+task CleanAll Clean,CleanModule
+
+# Synopsis: Deleting the content of the Build Output folder, except ./modules
 task Clean {
-    $LineSeparation
-    "`t`t`t CLEAN UP"
-    $LineSeparation
-
     if (![io.path]::IsPathRooted($BuildOutput)) {
-        $BuildOutput = Join-Path -Path $ProjectPath.FullName -ChildPath $BuildOutput
-    }
-    if (Test-Path $BuildOutput) {
-        "Removing $BuildOutput\*"
-        Gci .\BuildOutput\ -Exclude modules | Remove-Item -Force -Recurse
+        $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
     }
 
+    if (Test-Path $BuildOutput) {
+        Write-Build -Color Green "Removing $BuildOutput\* excluding modules"
+        Get-ChildItem $BuildOutput -Exclude modules | Remove-Item -Force -Recurse
+    }
 }
 
+# Synopsis: Removes the Modules from BuildOutput\Modules folder, might fail if there's an handle on one file.
 task CleanModule {
      if (![io.path]::IsPathRooted($BuildOutput)) {
-        $BuildOutput = Join-Path -Path $ProjectPath.FullName -ChildPath $BuildOutput
+        $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
     }
-    "Removing $BuildOutput\*"
-    Gci .\BuildOutput\ | Remove-Item -Force -Recurse -Verbose -ErrorAction Stop
+    Write-Build -Color Green "Removing $BuildOutput\*"
+    Get-ChildItem $BuildOutput | Remove-Item -Force -Recurse -Verbose -ErrorAction Stop
 }

--- a/.build/BuildHelpers/Environment.BuildHelpers.build.ps1
+++ b/.build/BuildHelpers/Environment.BuildHelpers.build.ps1
@@ -6,7 +6,8 @@ Param (
     $ForceEnvironmentVariables = $(try {property ForceEnvironmentVariables} catch {$false})
 )
 
-task SetBuildEnvironment {
+# Synopsis: Using Build Helpers to Set default environment variables
+task Set_Build_Environment_Variables {
     $BH_Params = @{
         variableNamePrefix = $VariableNamePrefix
         ErrorVariable      = 'err'
@@ -14,6 +15,7 @@ task SetBuildEnvironment {
         Force              = $ForceEnvironmentVariables
         Verbose            = $verbose
     }
+
     Set-BuildEnvironment @BH_Params
     foreach ($e in $err) {
         Write-Build Red $e

--- a/.build/BuildHelpers/Environment.BuildHelpers.build.ps1
+++ b/.build/BuildHelpers/Environment.BuildHelpers.build.ps1
@@ -1,8 +1,5 @@
 Param (
     [string]
-    $LineSeparation = (property LineSeparation ('-' * 78)),
-
-    [string]
     $VariableNamePrefix =  $(try {property VariableNamePrefix} catch {''}),
 
     [switch]
@@ -10,9 +7,6 @@ Param (
 )
 
 task SetBuildEnvironment {
-    $LineSeparation
-    "`t`t`t BUILD HELPERS INIT"
-    $LineSeparation
     $BH_Params = @{
         variableNamePrefix = $VariableNamePrefix
         ErrorVariable      = 'err'
@@ -22,6 +16,6 @@ task SetBuildEnvironment {
     }
     Set-BuildEnvironment @BH_Params
     foreach ($e in $err) {
-        Write-Host $e
+        Write-Build Red $e
     }
 }

--- a/.build/PSDeploy/DeployAll.PSDeploy.build.ps1
+++ b/.build/PSDeploy/DeployAll.PSDeploy.build.ps1
@@ -1,12 +1,9 @@
 Param (
-    [io.DirectoryInfo]
-    $ProjectPath = (property ProjectPath (Join-Path $PSScriptRoot '../..' -Resolve -ErrorAction SilentlyContinue)),
+    [string]
+    $BuildOutput = (property BuildOutput 'BuildOutput'),
 
     [string]
-    $BuildOutput = (property BuildOutput 'C:\BuildOutput'),
-
-    [string]
-    $ProjectName = (property ProjectName (Split-Path -Leaf (Join-Path $PSScriptRoot '../..')) ),
+    $ProjectName = (property ProjectName (Split-Path -Leaf $BuildRoot) ),
 
     [string]
     $PesterOutputFormat = (property PesterOutputFormat 'NUnitXml'),
@@ -20,15 +17,12 @@ Param (
 )
 
 task DeployAll {
-    $LineSeparation
-    "`t`t`t DEPLOYMENT "
-    $LineSeparation
 
     if (![io.path]::IsPathRooted($BuildOutput)) {
-        $BuildOutput = Join-Path -Path $ProjectPath.FullName -ChildPath $BuildOutput
+        $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
     }
 
-    $DeployFile =  [io.path]::Combine($ProjectPath, $DeployConfig)
+    $DeployFile =  [io.path]::Combine($BuildRoot, $DeployConfig)
     
     "Deploying Module based on $DeployConfig config"
     

--- a/.build/PSDeploy/DeployAll.PSDeploy.build.ps1
+++ b/.build/PSDeploy/DeployAll.PSDeploy.build.ps1
@@ -16,7 +16,8 @@ Param (
     $DeployConfig = (property DeployConfig 'Deploy.PSDeploy.ps1')
 )
 
-task DeployAll {
+# Synopsis: Deploy everything configured in PSDeploy
+task Deploy_with_PSDeploy {
 
     if (![io.path]::IsPathRooted($BuildOutput)) {
         $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
@@ -29,7 +30,6 @@ task DeployAll {
     $InvokePSDeployArgs = @{
         Path    = $DeployFile
         Force   = $true
-        Verbose = $true
     }
 
     if($DeploymentTags) {

--- a/.build/Pester/IntegrationTests.pester.build.ps1
+++ b/.build/Pester/IntegrationTests.pester.build.ps1
@@ -1,34 +1,27 @@
 Param (
-    [io.DirectoryInfo]
-    $ProjectPath = (property ProjectPath (Join-Path $PSScriptRoot '../..' -Resolve -ErrorAction SilentlyContinue)),
+    [string]
+    $ProjectName = (property ProjectName (Split-Path -Leaf $BuildRoot) ),
 
     [string]
-    $ProjectName = (property ProjectName (Split-Path -Leaf (Join-Path $PSScriptRoot '../..')) ),
-
-    [string]
-    $RelativePathToIntegrationTests = (property RelativePathToIntegrationTests 'tests/Integration'),
-
-    [string]
-    $LineSeparation = (property LineSeparation ('-' * 78))
+    $RelativePathToIntegrationTests = (property RelativePathToIntegrationTests 'tests/Integration')
 )
+
+# Synopsis: Running the Integration tests if present
 task IntegrationTests {
-    $LineSeparation
-    "`t`t`t RUNNING INTEGRATION TESTS"
-    $LineSeparation
-    "`tProject Path = $ProjectPath"
+    "`tProject Path = $BuildRoot"
     "`tProject Name = $ProjectName"
     "`tIntegration Tests   = $RelativePathToIntegrationTests"
-    $IntegrationTestPath = [io.DirectoryInfo][system.io.path]::Combine($ProjectPath,$ProjectName,$RelativePathToIntegrationTests)
+    $IntegrationTestPath = [io.DirectoryInfo][system.io.path]::Combine($BuildRoot,$ProjectName,$RelativePathToIntegrationTests)
      "`tIntegration Tests  = $IntegrationTestPath"
 
     if (!$IntegrationTestPath.Exists -and
         (   #Try a module structure where the
-            ($IntegrationTestPath = [io.DirectoryInfo][system.io.path]::Combine($ProjectPath,$RelativePathToIntegrationTests)) -and
+            ($IntegrationTestPath = [io.DirectoryInfo][system.io.path]::Combine($BuildRoot,$RelativePathToIntegrationTests)) -and
             !$IntegrationTestPath.Exists
         )
     )
     {
-        Write-Warning ('Integration tests Path Not found {0}' -f $IntegrationTestPath)
+        Write-Warning ("`t>> Integration tests Path Not found {0}" -f $IntegrationTestPath)
     }
     else {
         "`tIntegrationTest Path: $IntegrationTestPath"

--- a/.build/Pester/QualityTests.pester.build.ps1
+++ b/.build/Pester/QualityTests.pester.build.ps1
@@ -1,12 +1,9 @@
 Param (
-    [io.DirectoryInfo]
-    $ProjectPath = (property ProjectPath (Join-Path $PSScriptRoot '../..' -Resolve -ErrorAction SilentlyContinue)),
+    [string]
+    $BuildOutput = (property BuildOutput 'BuildOutput'),
 
     [string]
-    $BuildOutput = (property BuildOutput 'C:\BuildOutput'),
-
-    [string]
-    $ProjectName = (property ProjectName (Split-Path -Leaf (Join-Path $PSScriptRoot '../..')) ),
+    $ProjectName = (property ProjectName (Split-Path -Leaf $BuildRoot)),
 
     [string]
     $PesterOutputFormat = (property PesterOutputFormat 'NUnitXml'),
@@ -15,16 +12,11 @@ Param (
     $RelativePathToQualityTests = (property RelativePathToQualityTests 'tests/QA'),
 
     [string]
-    $PesterOutputSubFolder = (property PesterOutputSubFolder 'PesterOut'),
-
-    [string]
-    $LineSeparation = (property LineSeparation ('-' * 78))
+    $PesterOutputSubFolder = (property PesterOutputSubFolder 'PesterOut')
 )
 
-task QualityTests {
-    $LineSeparation
-    "`t`t`t RUNNING Quality TESTS"
-    $LineSeparation
+# Synopsis: Making sure the Module meets some quality standard (help, tests)
+task Quality_Tests {
     "`tProject Path = $ProjectPath"
     "`tProject Name = $ProjectName"
     "`tQuality Tests   = $RelativePathToQualityTests"
@@ -73,8 +65,9 @@ task QualityTests {
     Pop-Location
 }
 
-task FailBuildIfFailedQualityTest -If ($CodeCoverageThreshold -ne 0) {
+# Synopsis: 
+task Fail_Build_if_Quality_Tests_failed -If ($CodeCoverageThreshold -ne 0) {
     assert ($script:QualityTestResults.FailedCount -eq 0) ('Failed {0} Quality tests. Aborting Build' -f $script:QualityTestResults.FailedCount)
 }
 
-task QualityTestsStopOnFail QualityTests,FailBuildIfFailedQualityTest
+task QualityTestsStopOnFail Quality_Tests,Fail_Build_if_Quality_Tests_failed

--- a/.build/Pester/QualityTests.pester.build.ps1
+++ b/.build/Pester/QualityTests.pester.build.ps1
@@ -67,6 +67,7 @@ task Quality_Tests {
 
 # Synopsis: This task ensures the build job fails if the test aren't successful.
 task Fail_Build_if_Quality_Tests_failed -If ($CodeCoverageThreshold -ne 0) {
+    "Asserting that no Quality test failed"
     assert ($script:QualityTestResults.FailedCount -eq 0) ('Failed {0} Quality tests. Aborting Build' -f $script:QualityTestResults.FailedCount)
 }
 

--- a/.build/Pester/QualityTests.pester.build.ps1
+++ b/.build/Pester/QualityTests.pester.build.ps1
@@ -38,7 +38,7 @@ task Quality_Tests {
     if (![io.path]::IsPathRooted($BuildOutput)) {
         $BuildOutput = Join-Path -Path $ProjectPath.FullName -ChildPath $BuildOutput
     }
-    # $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(".\nonexist\foo.txt")
+    
     $PSVersion = 'PSv{0}.{1}' -f $PSVersionTable.PSVersion.Major, $PSVersionTable.PSVersion.Minor
     $Timestamp = Get-date -uformat "%Y%m%d-%H%M%S"
     $TestResultFileName = "QA_$PSVersion`_$TimeStamp.xml"
@@ -65,9 +65,10 @@ task Quality_Tests {
     Pop-Location
 }
 
-# Synopsis: 
+# Synopsis: This task ensures the build job fails if the test aren't successful.
 task Fail_Build_if_Quality_Tests_failed -If ($CodeCoverageThreshold -ne 0) {
     assert ($script:QualityTestResults.FailedCount -eq 0) ('Failed {0} Quality tests. Aborting Build' -f $script:QualityTestResults.FailedCount)
 }
 
-task QualityTestsStopOnFail Quality_Tests,Fail_Build_if_Quality_Tests_failed
+# Synopsis: Meta task that runs Quality Tests, and fails if they're not successful
+task Pester_Quality_Tests_Stop_On_Fail Quality_Tests,Fail_Build_if_Quality_Tests_failed

--- a/.build/Pester/UnitTests.pester.build.ps1
+++ b/.build/Pester/UnitTests.pester.build.ps1
@@ -22,7 +22,8 @@ Param (
     $CodeCoverageThreshold = (property CodeCoverageThreshold 90)
 )
 
-task Unit_Tests {
+# Synopsis: Execute the Pester Unit tests
+task Run_Unit_Tests {
     "`tProject Path = $BuildRoot"
     "`tProject Name = $ProjectName"
     "`tUnit Tests   = $PathToUnitTests"
@@ -109,10 +110,12 @@ task Unit_Tests {
     Pop-Location
 }
 
+# Synopsis: If the Unit test failed, fail the build (unless Threshold is set to 0)
 task Fail_Build_if_Unit_Test_Failed -If ($CodeCoverageThreshold -ne 0) {
     assert ($script:UnitTestResults.FailedCount -eq 0) ('Failed {0} Unit tests. Aborting Build' -f $script:UnitTestResults.FailedCount)
 }
 
+# Synopsis: If the Code coverage is under the defined threshold, fail the build
 task Fail_if_Last_Code_Converage_is_Under_Threshold {
     "`tProject Path     = $BuildRoot"
     "`tProject Name     = $ProjectName"
@@ -150,4 +153,7 @@ task Fail_if_Last_Code_Converage_is_Under_Threshold {
     }
 }
 
-task Pester_Unit_Tests_Stop_On_Fail Unit_Tests,Fail_Build_if_Unit_Test_Failed,Fail_if_Last_Code_Converage_is_Under_Threshold
+# Synopsis: Task to Run the unit tests and fail build if failed or if the code coverage is under threshold
+task Pester_Unit_Tests_Stop_On_Fail Run_Unit_Tests,
+                                    Fail_Build_if_Unit_Test_Failed,
+                                    Fail_if_Last_Code_Converage_is_Under_Threshold

--- a/.build/Pester/UnitTests.pester.build.ps1
+++ b/.build/Pester/UnitTests.pester.build.ps1
@@ -22,7 +22,7 @@ Param (
     $CodeCoverageThreshold = (property CodeCoverageThreshold 90)
 )
 
-task UnitTests {
+task Unit_Tests {
     "`tProject Path = $BuildRoot"
     "`tProject Name = $ProjectName"
     "`tUnit Tests   = $PathToUnitTests"
@@ -109,11 +109,11 @@ task UnitTests {
     Pop-Location
 }
 
-task FailBuildIfFailedUnitTest -If ($CodeCoverageThreshold -ne 0) {
+task Fail_Build_if_Unit_Test_Failed -If ($CodeCoverageThreshold -ne 0) {
     assert ($script:UnitTestResults.FailedCount -eq 0) ('Failed {0} Unit tests. Aborting Build' -f $script:UnitTestResults.FailedCount)
 }
 
-task FailIfLastCodeConverageUnderThreshold {
+task Fail_if_Last_Code_Converage_is_Under_Threshold {
     "`tProject Path     = $BuildRoot"
     "`tProject Name     = $ProjectName"
     "`tUnit Tests       = $PathToUnitTests"
@@ -150,4 +150,4 @@ task FailIfLastCodeConverageUnderThreshold {
     }
 }
 
-task UnitTestsStopOnFail UnitTests,FailBuildIfFailedUnitTest,FailIfLastCodeConverageUnderThreshold
+task Pester_Unit_Tests_Stop_On_Fail Unit_Tests,Fail_Build_if_Unit_Test_Failed,Fail_if_Last_Code_Converage_is_Under_Threshold

--- a/.build/Release/MergeModule.Release.build.ps1
+++ b/.build/Release/MergeModule.Release.build.ps1
@@ -1,9 +1,6 @@
 ﻿Param (
-    [io.DirectoryInfo]
-    $ProjectPath = (property ProjectPath (Join-Path $PSScriptRoot '../..' -Resolve -ErrorAction SilentlyContinue)),
-
     [string]
-    $ProjectName = (property ProjectName (Split-Path -Leaf (Join-Path $PSScriptRoot '../..')) ),
+    $ProjectName = (property ProjectName (Split-Path -Leaf $BuildRoot) ),
 
     [string]
     $SourceFolder = $ProjectName,
@@ -24,25 +21,18 @@
 )
 
 Task CopySourceToModuleOut {
-    $LineSeparation
-    "`t`t`t COPY SOURCE TO BUILD OUTPUT"
-    $LineSeparation
-
     if (![io.path]::IsPathRooted($BuildOutput)) {
-        $BuildOutput = Join-Path -Path $ProjectPath.FullName -ChildPath $BuildOutput
+        $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
     }
     $BuiltModuleFolder = [io.Path]::Combine($BuildOutput,$ProjectName)
-    "Copying $ProjectPath\$SourceFolder To $BuiltModuleFolder\"
-    Copy-Item -Path "$ProjectPath\$SourceFolder" -Destination "$BuiltModuleFolder\" -Recurse -Force -Exclude '*.bak'
+    "Copying $BuildRoot\$SourceFolder To $BuiltModuleFolder\"
+    Copy-Item -Path "$BuildRoot\$SourceFolder" -Destination "$BuiltModuleFolder\" -Recurse -Force -Exclude '*.bak'
 }
 
 Task MergeFilesToPSM1 {
-    $LineSeparation
-    "`t`t`t MERGE TO PSM1"
-    $LineSeparation
     "`tORDER: $($MergeList.ToString())"
     if (![io.path]::IsPathRooted($BuildOutput)) {
-        $BuildOutput = Join-Path -Path $ProjectPath.FullName -ChildPath $BuildOutput
+        $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
     }
     $BuiltModuleFolder = [io.Path]::Combine($BuildOutput,$ProjectName)
     if(!$MergeList) {$MergeList = @('enum*','class*','priv*','pub*') }
@@ -54,11 +44,9 @@ Task MergeFilesToPSM1 {
 }
 
 Task CleanOutputEmptyFolders {
-    $LineSeparation
-    "`t`t`t REMOVE EMPTY FOLDERS"
-    $LineSeparation
+
     if (![io.path]::IsPathRooted($BuildOutput)) {
-        $BuildOutput = Join-Path -Path $ProjectPath.FullName -ChildPath $BuildOutput
+        $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
     }
 
     Get-ChildItem $BuildOutput -Recurse -Force | Sort-Object -Property FullName -Descending | Where-Object {
@@ -69,12 +57,9 @@ Task CleanOutputEmptyFolders {
 }
 
 Task UpdateModuleManifest {
-    $LineSeparation
-    "`t`t`t UPDATE MODULE MANIFEST"
-    $LineSeparation
 
     if (![io.path]::IsPathRooted($BuildOutput)) {
-        $BuildOutput = Join-Path -Path $ProjectPath.FullName -ChildPath $BuildOutput
+        $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
     }
     $BuiltModule = [io.path]::Combine($BuildOutput,$ProjectName,"$ProjectName.psd1")
     Set-ModuleFunctions -Path $BuiltModule

--- a/.build/Release/MergeModule.Release.build.ps1
+++ b/.build/Release/MergeModule.Release.build.ps1
@@ -20,7 +20,8 @@
 
 )
 
-Task CopySourceToModuleOut {
+# Synopsis: Copy the Module Source files to the BuildOutput
+Task Copy_Source_To_Module_BuildOutput {
     if (![io.path]::IsPathRooted($BuildOutput)) {
         $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
     }
@@ -29,7 +30,8 @@ Task CopySourceToModuleOut {
     Copy-Item -Path "$BuildRoot\$SourceFolder" -Destination "$BuiltModuleFolder\" -Recurse -Force -Exclude '*.bak'
 }
 
-Task MergeFilesToPSM1 {
+# Synopsis: Merging the PS1 files into the PSM1.
+Task Merge_Source_Files_To_PSM1 {
     "`tORDER: $($MergeList.ToString())"
     if (![io.path]::IsPathRooted($BuildOutput)) {
         $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
@@ -43,7 +45,8 @@ Task MergeFilesToPSM1 {
     $MergeList | Get-MergedModule -DeleteSource -SourceFolder $BuiltModuleFolder | Out-File $OutModulePSM1 -Force
 }
 
-Task CleanOutputEmptyFolders {
+# Synopsis: Removing Empty folders from the Module Build output
+Task Clean_Empty_Folders_from_Build_Output {
 
     if (![io.path]::IsPathRooted($BuildOutput)) {
         $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput
@@ -56,7 +59,8 @@ Task CleanOutputEmptyFolders {
     } | Remove-Item
 }
 
-Task UpdateModuleManifest {
+# Synopsis: Update the Module Manifest with the $ModuleVersion and setting the module functions
+Task Update_Module_Manifest {
 
     if (![io.path]::IsPathRooted($BuildOutput)) {
         $BuildOutput = Join-Path -Path $BuildRoot -ChildPath $BuildOutput

--- a/SampleModule/tests/QA/module.tests.ps1
+++ b/SampleModule/tests/QA/module.tests.ps1
@@ -5,7 +5,7 @@ $modulePath = "$here\..\.."
 $moduleName = Split-Path -Path $modulePath -Leaf
 
 
-Describe 'General module control' -Tags 'FunctionalQuality'   {
+Describe 'General module control' -Tags 'FunctionalQuality'  {
 
     It 'imports without errors' {
         { Import-Module -Name $modulePath -Force -ErrorAction Stop } | Should Not Throw
@@ -45,8 +45,8 @@ foreach ($function in $allModuleFunctions) {
         if ($scriptAnalyzerRules) {
             It "Script Analyzer for $($function.BaseName)" {
                 forEach ($scriptAnalyzerRule in $scriptAnalyzerRules) {
-                    (Invoke-ScriptAnalyzer -Path $function.FullName -IncludeRule $scriptAnalyzerRule).count |
-                         Should Be 0
+                    $PSSAResult = (Invoke-ScriptAnalyzer -Path $function.FullName -IncludeRule $scriptAnalyzerRule)
+                    ($PSSAResult | Select-Object Message,Line | Out-String) | Should -BeNullOrEmpty
                 }
             }
         }


### PR DESCRIPTION
I'm now leveraging a feature from InvokeBuild to improve on the formatting done by InvokeBuild.

It now uses a header using the [`Set-BuildHeader`](https://github.com/nightroman/Invoke-Build/tree/master/Tasks/Header).
The default allows coloured output of task and display Task Name, synopsis, Task path, and task file.
See this [Appveyor build log](https://ci.appveyor.com/project/gaelcolas/samplemodule/build/1.0.141).
```
==============================================================================
			SET BUILD ENVIRONMENT VARIABLES
Using Build Helpers to Set default environment variables
-------------------------------------------------------------------------------
  /./Set_Build_Environment_Variables
  C:\projects\samplemodule\.build\BuildHelpers\Environment.BuildHelpers.build.ps1:10
...
Done /./Set_Build_Environment_Variables 00:00:00.2187430
===============================================================================
```

There is also an improved output in the PS Script Analyser Pester tests, to display the Message and Line when a rule is matched.
