### PR TITLE
updated pester build for cross-platform support

### DIFF
--- a/.build/Pester/QualityTests.pester.build.ps1
+++ b/.build/Pester/QualityTests.pester.build.ps1
@@ -49,12 +49,12 @@ task Quality_Tests {
     
     if (!(Test-Path $PesterOutParentFolder)) {
         Write-Verbose "CREATING Pester Results Output Folder $PesterOutParentFolder"
-        $null = mkdir $PesterOutParentFolder -Force
+        $null = New-Item -Path $PesterOutParentFolder -ItemType Directory -Force
     }
 
     if (!(Test-Path $TestResultFileParentFolder)) {
         Write-Verbose "CREATING Test Results Output Folder $TestResultFileParentFolder"
-        $null = mkdir $TestResultFileParentFolder -Force
+        $null = New-Item -Path $TestResultFileParentFolder -ItemType Directory -Force
     }
 
     Push-Location $QualityTestPath

--- a/.build/Pester/UnitTests.pester.build.ps1
+++ b/.build/Pester/UnitTests.pester.build.ps1
@@ -69,12 +69,12 @@ task Run_Unit_Tests {
     
     if (!(Test-Path $PesterOutParentFolder)) {
         Write-Verbose "CREATING Pester Results Output Folder $PesterOutParentFolder"
-        $null = mkdir $PesterOutParentFolder -Force
+        $null = New-Item -Path $PesterOutParentFolder -ItemType Directory -Force
     }
 
     if (!(Test-Path $TestResultFileParentFolder)) {
         Write-Verbose "CREATING Test Results Output Folder $TestResultFileParentFolder"
-        $null = mkdir $TestResultFileParentFolder -Force
+        $null = New-Item -Path $TestResultFileParentFolder -ItemType Directory -Force
     }
     
     Push-Location $UnitTestPath


### PR DESCRIPTION
On macOS the mkdir invocation in the pester build scripts used to create the pester output and test result folders fails as below and instead creates a '-Force' folder.

mkdir: /Users/tom/Documents/Dev/tools/BuildOutput/testResults/QA: No such file or directory
mkdir: /Users/tom/Documents/Dev/tools/BuildOutput/testResults/QA: No such file or directory
mkdir: -Force: File exists

Using New-Item -ItemType Directory -Force instead works fine